### PR TITLE
Lumen support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,10 @@
   ],
   "require": {
     "php": ">=7.1.0",
-    "laravel/framework": "^7.0|^8.0",
     "smi2/phpclickhouse": "^1.3",
-    "the-tinderbox/clickhouse-builder": "^3.0|^4.0"
-  },
-  "require-dev": {
+    "the-tinderbox/clickhouse-builder": "^3.0|^4.0",
+    "illuminate/support": "^7.0|^8.0",
+    "illuminate/database": "^7.0|^8.0"
   },
   "suggest": {
   },
@@ -32,4 +31,3 @@
     }
   }
 }
-


### PR DESCRIPTION
It's not necessary to add `laravel/framework` in require list.
I added only required packages of laravel ecosystem. The Lumen Framework will be supported after this change.