### PR TITLE
Add support for Laravel migration pretend mode

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -18,6 +18,16 @@ class Migration extends BaseMigration
      */
     protected static function write(string $sql, array $bindings = []): Statement
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 6);
+        $isPretend = $trace['5']['function'] == 'pretend';
+
+        if ($isPretend) {
+            $output = new \Symfony\Component\Console\Output\ConsoleOutput();
+            $name = static::class;
+            $output->writeln("<comment>Clickhouse</comment> <info>{$name}:</info> $sql");
+            return new Statement(new \ClickHouseDB\Transport\CurlerRequest());
+        }
+
         /** @var Client $client */
         $client = DB::connection('clickhouse')->getClient();
 


### PR DESCRIPTION
In Laravel there is migration pretend mode, when migration is not really applied but shows SQL that will be applied. However this mode is not supported by `phpclickhouse-laravel`. 
This can cause issues when user launches DB-migrations with `artisan migrate --pretend` and expects that migrations will be applied but only shown. So I added the support for pretend mode.