### PR TITLE
Fix complying with psr-4 autoloading standard.

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -7,6 +7,7 @@ namespace PhpClickHouseLaravel;
 use ClickHouseDB\Client;
 use ClickHouseDB\Statement;
 use Illuminate\Support\Facades\DB;
+use PhpClickHouseLaravel\Exceptions\QueryException;
 use Tinderbox\ClickhouseBuilder\Query\BaseBuilder;
 use Tinderbox\ClickhouseBuilder\Query\Grammar;
 

--- a/src/Exceptions/QueryException.php
+++ b/src/Exceptions/QueryException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpClickHouseLaravel;
+namespace PhpClickHouseLaravel\Exceptions;
 
 
 class QueryException extends \ClickHouseDB\Exception\QueryException


### PR DESCRIPTION
When I run `composer update` 

I get this message:
`Class PhpClickHouseLaravel\QueryException located in ./vendor/glushkovds/phpclickhouse-laravel/src/Exceptions/QueryException.php does not comply with psr-4 autoloading standard. Skipping.`

This minor `pull request` fixes namespace.