### PR TITLE
Update Base model for connection flexibility.

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -57,6 +57,14 @@ class BaseModel
      * @var Dispatcher
      */
     protected static $dispatcher;
+    
+    
+    /**
+     * The name of connection.
+     *
+     * @var string
+     */
+    public $connection = 'clickhouse';
 
     /**
      * Get the table associated with the model.
@@ -92,7 +100,7 @@ class BaseModel
      */
     public static function getClient(): Client
     {
-        return DB::connection('clickhouse')->getClient();
+        return DB::connection($this->connection)->getClient();
     }
 
     /**


### PR DESCRIPTION
We use several Clickhouses in our projects, and adding this variable will allow us to use this library more flexibly.

Because if we try to override getClient method, we get phpstan error, code duplicating... but we can in model simply override connection property.