### PR TITLE
Update RawColumn.php

### DIFF
--- a/src/RawColumn.php
+++ b/src/RawColumn.php
@@ -12,7 +12,7 @@ class RawColumn extends Expression
      * Create a new raw query expression.
      *
      * @param mixed $value
-     * @param null $alias
+     * @param string|null $alias
      */
     public function __construct($value, $alias = null)
     {


### PR DESCRIPTION
Phpstan on 5 level give error, because in RawColumn DocBlock is inconsistent with parameters given when calling RawColumn class in code ex. new RawColumn("sspName", "ssp") cause this error: "Parameter #2 $alias of class PhpClickHouseLaravel\RawColumn constructor expects null, string given."