### PR TITLE
Log query events

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpClickHouseLaravel;
 
 use ClickHouseDB\Client;
+use Closure;
 use Illuminate\Database\Connection as BaseConnection;
 
 class Connection extends BaseConnection
@@ -76,18 +77,36 @@ class Connection extends BaseConnection
     {
         $query = QueryGrammar::prepareParameters($query);
 
-        return $this->client->select($query, $bindings)->rows();
+        return $this->run($query, $bindings, function ($query, $bindings) {
+            return $this->client->select($query, $bindings)->rows();
+        });
     }
 
     /** @inheritDoc */
     public function statement($query, $bindings = []): bool
     {
-        return !$this->client->write($query, $bindings)->isError();
+        return $this->run($query, $bindings, function ($query, $bindings) {
+            return !$this->client->write($query, $bindings)->isError();
+        });
     }
 
     /** @inheritDoc */
     public function affectingStatement($query, $bindings = []): int
     {
-        return (int)$this->statement($query, $bindings);
+        return $this->run($query, $bindings, function ($query, $bindings) {
+            return (int)$this->statement($query, $bindings);
+        });
+    }
+
+    /** @inheritDoc */
+    protected function run($query, $bindings, Closure $callback)
+    {
+        $start = microtime(true);
+
+        $result = $callback($query, $bindings);
+
+        $this->logQuery($query, $bindings, $this->getElapsedTime($start));
+
+        return $result;
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -93,9 +93,7 @@ class Connection extends BaseConnection
     /** @inheritDoc */
     public function affectingStatement($query, $bindings = []): int
     {
-        return $this->run($query, $bindings, function ($query, $bindings) {
-            return (int)$this->statement($query, $bindings);
-        });
+        return (int)$this->statement($query, $bindings);
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
Hey there!

I noticed that this package does not emit `QueryExecuted` events. These are really helpful with tools like [Laravel Pulse](https://github.com/laravel/pulse) and [Laravel Debugbar](https://github.com/barryvdh/laravel-debugbar), which can show query timings to help assess their performance.

To solve this, I've used Laravel's `logQuery` method and passed all queries through a `run` method, which loosely follows the [default `run` method](https://github.com/laravel/framework/blob/6c0561caeb8265b7d17cabeea0ec7d4c5cca28aa/src/Illuminate/Database/Connection.php#L753) on Laravel's `Connection` class.