### PR TITLE
Fix parameter numbering with whereIn and nested where

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -77,6 +77,7 @@ class Connection extends BaseConnection
     /** @inheritDoc */
     public function statement($query, $bindings = []): bool
     {
+        $query = QueryGrammar::prepareParameters($query);
         return $this->run($query, $bindings, function ($query, $bindings) {
             return !$this->cluster->getActiveNode()->write($query, $bindings)->isError();
         });
@@ -85,6 +86,7 @@ class Connection extends BaseConnection
     /** @inheritDoc */
     public function affectingStatement($query, $bindings = []): int
     {
+        $query = QueryGrammar::prepareParameters($query);
         return (int)$this->statement($query, $bindings);
     }
 

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -12,17 +12,6 @@ class QueryGrammar extends Grammar
     const PARAMETER_SIGN = '#@?';
 
     /** @inheritDoc */
-    public function parameterize(array $values): string
-    {
-        $params = [];
-        for ($i = 0; $i < count($values); $i++) {
-            $params[] = ":$i";
-        }
-
-        return implode(', ', $params);
-    }
-
-    /** @inheritDoc */
     public function parameter($value)
     {
         return $this->isExpression($value) ? $this->getValue($value) : self::PARAMETER_SIGN;

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -17,12 +17,6 @@ class QueryGrammar extends Grammar
         return $this->isExpression($value) ? $this->getValue($value) : self::PARAMETER_SIGN;
     }
 
-    /** @inheritDoc */
-    public function compileWheres(Builder $query)
-    {
-        return static::prepareParameters(parent::compileWheres($query));
-    }
-
     /**
      * Second part of trick to change signs "?" to ":0", ":1" and so on
      * @param string $sql


### PR DESCRIPTION
This PR fixes a bug when using a `whereIn` query combined with a `where` query.

Take the following query:

```php
DB::table('my-table')
    ->where('column1', 1)
    ->whereIn('column2', ['foo', 'bar'])
    ->get();
```

Currently, the SQL will be generated as:

```sql
select * from "my-table" where "column1" = :0 and "column2" in (:0, :1)
```

Notice how the parameters in the `in()` clause start at `:0` instead of `:1`.

A similar issue happens when switching the order of the `where` and `whereIn`:

```php
DB::table('my-table')
    ->whereIn('column2', ['foo', 'bar'])
    ->where('column1', 1)
    ->get();
```

```sql
select * from "my-table" where "column2" in (:0, :1) and "column1" = :0
```

In this example, the `column` condition is using `:0` instead of `:2`.

This is because the `whereIn` method is currently working in isolation from the query bindings, and will only work when there are no other bindings in the query.

This PR solves this issue by removing the custom implementation of the `parameterize` method and using the parent implementation instead.

This results in the following SQL for the above two queries:

```sql
select * from "my-table" where "column1" = :0 and "column2" in (:1, :2)
```

```sql
select * from "my-table" where "column2" in (:0, :1) and "column1" = :2
```

I'm assuming there was a reason why the `parameterize` method was customized but I'm not sure what it was or whether it's still relevant. I couldn't get the tests running locally to check for any regressions.