### PR TITLE
fix laravel 12 issue with getDefaultQueryGrammar

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -44,12 +44,6 @@ class Connection extends BaseConnection
     }
 
     /** @inheritDoc */
-    protected function getDefaultQueryGrammar()
-    {
-        return new QueryGrammar();
-    }
-
-    /** @inheritDoc */
     protected function getDefaultSchemaGrammar()
     {
         return new SchemaGrammar();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -44,6 +44,12 @@ class Connection extends BaseConnection
     }
 
     /** @inheritDoc */
+    protected function getDefaultQueryGrammar()
+    {
+        return new QueryGrammar();
+    }
+
+    /** @inheritDoc */
     protected function getDefaultSchemaGrammar()
     {
         return new SchemaGrammar();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -46,7 +46,7 @@ class Connection extends BaseConnection
     /** @inheritDoc */
     protected function getDefaultQueryGrammar()
     {
-        return new QueryGrammar();
+        return new QueryGrammar($this);
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
This PR fixes this issue with Laravel 12:
`
 Too few arguments to function Illuminate\\Database\\Grammar::__construct(), 0 passed in /var/www/vendor/glushkovds/phpclickhouse-laravel/src/Connection.php on line 49 and exactly 1 expected at /var/www/vendor/laravel/framework/src/Illuminate/Database/Grammar.php:27)`