### PR TITLE
Allow us to run `beforeExecutingCallbacks()`

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -93,6 +93,10 @@ class Connection extends BaseConnection
     /** @inheritDoc */
     protected function run($query, $bindings, Closure $callback)
     {
+        foreach ($this->beforeExecutingCallbacks as $beforeExecutingCallback) {
+            $beforeExecutingCallback($query, $bindings, $this);
+        }
+
         $start = microtime(true);
 
         $result = $callback($query, $bindings);


### PR DESCRIPTION
I was trying to create a trait for use in my tests that would automatically refresh my Clickhouse database if any Clickhouse queries had been run, but i realised the `beforeExecutingCallbacks()` were not getting executed in the `run()` method.

This PR addresses that issue.