### PR TITLE
Update fireModelEvent('creating') to follow Laravel behavior and support early return

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -149,7 +149,10 @@ class BaseModel
     public static function create(array $attributes = [])
     {
         $model = static::make($attributes);
-        $model->fireModelEvent('creating', false);
+
+        if ($model->fireModelEvent('creating', false) === false) {
+            return false;
+        }
 
         if ($model->save()) {
             $model->wasRecentlyCreated = true;

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -150,7 +150,7 @@ class BaseModel
     {
         $model = static::make($attributes);
 
-        if ($model->fireModelEvent('creating', false) === false) {
+        if ($model->fireModelEvent('creating') === false) {
             return false;
         }
 


### PR DESCRIPTION
This change allows any registered creating event listeners to prevent the model from being created by returning false, aligning the behavior with Laravel's Eloquent ORM.

This change ensures compatibility with Laravel's expected behavior for model events, specifically for creating, where returning false is a documented way to cancel the operation.

Reference from the Laravel source: https://github.com/laravel/framework/blob/44e6a294e4441e9e3338008af0288979b3f677e8/src/Illuminate/Database/Eloquent/Model.php#L1356
