### PR TITLE
Replace Eloquent HasEvents trait with a minimal custom implementation

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -7,9 +7,8 @@ namespace PhpClickHouseLaravel;
 use ClickHouseDB\Client;
 use ClickHouseDB\Statement;
 use Exception;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Concerns\HasAttributes;
-use Illuminate\Database\Eloquent\Concerns\HasEvents;
+use PhpClickHouseLaravel\Concerns\HasEvents;
 use Illuminate\Database\Eloquent\Concerns\HidesAttributes;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -58,13 +57,6 @@ class BaseModel
      * @var bool
      */
     public $wasRecentlyCreated = false;
-
-    /**
-     * The event dispatcher instance.
-     *
-     * @var Dispatcher
-     */
-    protected static $dispatcher;
 
     /**
      * The name of the database connection to use.

--- a/src/Concerns/HasEvents.php
+++ b/src/Concerns/HasEvents.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpClickHouseLaravel\Concerns;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Events\NullDispatcher;
+
+/**
+ * Minimal event dispatching for ClickHouse models.
+ *
+ * Unlike Eloquent's HasEvents trait, this does not require extending
+ * Illuminate\Database\Eloquent\Model, making it compatible with
+ * ClickHouse's BaseModel, which is not an Eloquent model.
+ *
+ * Supports: creating, created, saved events (the events BaseModel actually fires).
+ * Does not include: observers, $dispatchesEvents mapping, bootHasEvents, or
+ * attribute-based observer registration — these are Eloquent-specific features.
+ */
+trait HasEvents
+{
+    /**
+     * @var Dispatcher|null
+     */
+    protected static $dispatcher;
+
+    /**
+     * @param string $event
+     * @param bool $halt
+     *
+     * @return mixed
+     */
+    protected function fireModelEvent(string $event, bool $halt = true): mixed
+    {
+        if (!isset(static::$dispatcher)) {
+            return true;
+        }
+
+        $method = $halt ? 'until' : 'dispatch';
+
+        return static::$dispatcher->{$method}(
+            "eloquent.{$event}: " . static::class,
+            $this
+        );
+    }
+
+    /**
+     * @return Dispatcher|null
+     */
+    public static function getEventDispatcher(): ?Dispatcher
+    {
+        return static::$dispatcher;
+    }
+
+    /**
+     * @param Dispatcher $dispatcher
+     *
+     * @return void
+     */
+    public static function setEventDispatcher(Dispatcher $dispatcher): void
+    {
+        static::$dispatcher = $dispatcher;
+    }
+
+    /**
+     * @return void
+     */
+    public static function unsetEventDispatcher(): void
+    {
+        static::$dispatcher = null;
+    }
+
+    /**
+     * @param callable $callback
+     *
+     * @return mixed
+     */
+    public static function withoutEvents(callable $callback): mixed
+    {
+        $dispatcher = static::getEventDispatcher();
+
+        if ($dispatcher) {
+            static::setEventDispatcher(new NullDispatcher($dispatcher));
+        }
+
+        try {
+            return $callback();
+        } finally {
+            if ($dispatcher) {
+                static::setEventDispatcher($dispatcher);
+            }
+        }
+    }
+}

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use PhpClickHouseLaravel\BaseModel;
+
+class EventsTestModel extends BaseModel
+{
+    protected $table = 'events_test';
+
+    public function fireModelEvent(string $event, bool $halt = true): mixed
+    {
+        return parent::fireModelEvent($event, $halt);
+    }
+}
+
+class EventsTest extends PHPUnitTestCase
+{
+    protected function tearDown(): void
+    {
+        BaseModel::unsetEventDispatcher();
+        parent::tearDown();
+    }
+
+    public function testFireModelEventReturnsTrueWithoutDispatcher(): void
+    {
+        BaseModel::unsetEventDispatcher();
+
+        $model = new EventsTestModel();
+
+        $this->assertTrue($model->fireModelEvent('creating'));
+    }
+
+    public function testCreatingEventCanHaltCreation(): void
+    {
+        $dispatcher = $this->createMock(Dispatcher::class);
+        $dispatcher->method('until')->willReturn(false);
+        BaseModel::setEventDispatcher($dispatcher);
+
+        $result = EventsTestModel::create(['field1' => 'value1']);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCreatedEventFires(): void
+    {
+        $firedEvents = [];
+        BaseModel::setEventDispatcher($this->mockDispatcher($firedEvents));
+
+        $model = new EventsTestModel();
+        $model->fireModelEvent('created', false);
+
+        $this->assertContains('eloquent.created: ' . EventsTestModel::class, $firedEvents);
+    }
+
+    public function testSavedEventFires(): void
+    {
+        $firedEvents = [];
+        BaseModel::setEventDispatcher($this->mockDispatcher($firedEvents));
+
+        $model = new EventsTestModel();
+        $model->fireModelEvent('saved', false);
+
+        $this->assertContains('eloquent.saved: ' . EventsTestModel::class, $firedEvents);
+    }
+
+    /**
+     * @param array<string> $firedEvents
+     */
+    private function mockDispatcher(array &$firedEvents): Dispatcher
+    {
+        $dispatcher = $this->createMock(Dispatcher::class);
+
+        $dispatcher->method('until')
+            ->willReturnCallback(function (string $event) use (&$firedEvents) {
+                $firedEvents[] = $event;
+                return true;
+            });
+
+        $dispatcher->method('dispatch')
+            ->willReturnCallback(function (string $event) use (&$firedEvents) {
+                $firedEvents[] = $event;
+                return [true];
+            });
+
+        return $dispatcher;
+    }
+}


### PR DESCRIPTION
Larastan v3 added `@phpstan-require-extends` to Eloquent's `HasEvents` trait, causing `class.missingExtends` errors for all ClickHouse models since BaseModel does not extend Eloquent Model.

Replaced with a minimal HasEvents trait that provides only the event dispatching BaseModel actually uses (`creating`, `created`, `saved`), without requiring Eloquent Model inheritance.

Closes #47