### PR TITLE
Fix: Dynamic property deprecation in `Builder::aggregate()` due to incompatible `cloneWithout()` call

### DIFF
--- a/src/BuilderMethodsFromLaravel.php
+++ b/src/BuilderMethodsFromLaravel.php
@@ -220,7 +220,7 @@ trait BuilderMethodsFromLaravel
      */
     public function aggregate($function, $columns = ['*'])
     {
-        $results = $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
+        $results = $this->cloneWithout($this->unions || $this->havings ? [] : ['columns' => []])
             ->setAggregate($function, $columns)
             ->getRows();
 


### PR DESCRIPTION
### Problem

On PHP 8.2+, calling `sum()`, `avg()`, `min()`, or `max()` on the Builder triggers:

```
Creation of dynamic property PhpClickHouseLaravel\Builder::$0 is deprecated
```

### Root Cause

The `aggregate()` method in `BuilderMethodsFromLaravel` (line 223) calls:

```php
$this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
```

This passes a **numeric** array `['columns']` (where key `0` maps to value `'columns'`).

However, `BaseBuilder::cloneWithout()` expects an **associative** array, iterating like so:

```php
foreach ($except as $property => $value) {
    $clone->{$property} = $value;
}
```

With the numeric array, this evaluates to `$clone->{0} = 'columns'`, creating a dynamic property `$0` on the Builder instance. This is deprecated in PHP 8.2 and will become a fatal error in PHP 9.0.

Additionally, the intended behavior of clearing the `columns` property never actually happens — it gets set to the string `'columns'` on a nonexistent property instead of resetting `$columns` to an empty array.

### Fix

Change the array from numeric to associative, matching the convention already used by `BaseBuilder::getCountQuery()`:

```diff
- $results = $this->cloneWithout($this->unions || $this->havings ? [] : ['columns'])
+ $results = $this->cloneWithout($this->unions || $this->havings ? [] : ['columns' => []])
```

### Affected Methods

All aggregate methods that route through `aggregate()` are affected:

- `sum()`
- `avg()`
- `min()`
- `max()`

### Reference

`BaseBuilder::getCountQuery()` already uses the correct associative format:

```php
$without = ['columns' => [], 'limit' => null];
```

