### PR TITLE
fix(Connection): add  parameter to select() for Laravel 13 compatibility

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -66,7 +66,7 @@ class Connection extends BaseConnection
     }
 
     /** @inheritDoc */
-    public function select($query, $bindings = [], $useReadPdo = true): array
+    public function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []): array
     {
         $query = QueryGrammar::prepareParameters($query);
         return $this->run($query, $bindings, function ($query, $bindings) {


### PR DESCRIPTION
- Laravel 13 introduces a `$fetchUsing` parameter to the base `Illuminate\Database\Connection::select()` method signature
- Updated `Connection::select()` override to include the new `array $fetchUsing = []` parameter, preventing method signature mismatch errors
- **Note:** This change only ensures compatibility for users upgrading to Laravel 13 — it does not implement full Laravel 13 support or utilize the new `$fetchUsing` functionality.