### PR TITLE
Fix CurlerRollingWithRetries::execOne definition to match smi2/phpClickHouse v1.26.406

### DIFF
--- a/src/CurlerRollingWithRetries.php
+++ b/src/CurlerRollingWithRetries.php
@@ -15,7 +15,7 @@ class CurlerRollingWithRetries extends CurlerRolling
     protected $retries = 0;
 
     /** @inheritDoc */
-    public function execOne(CurlerRequest $request, $auto_close = false)
+    public function execOne(CurlerRequest $request, bool $auto_close = false): int
     {
         $attempts = 1 + max(0, $this->retries);
         $httpCode = 0;


### PR DESCRIPTION
With the recent updates in smi2/phpClickHouse in version >= 1.26.406, the function uses strict type hints to execOne().

This change is meant to match smi2/phpClickHouse v1.26.406:
https://github.com/smi2/phpClickHouse/compare/1.26.4...1.26.406#diff-a7468307f38aae2f44fd5169979b48708c5e2d2ee092280b115c911fa1a161caR246